### PR TITLE
API client for reserving a path.

### DIFF
--- a/lib/govuk/client/response.rb
+++ b/lib/govuk/client/response.rb
@@ -1,0 +1,23 @@
+require 'delegate'
+require 'multi_json'
+
+module GOVUK
+  module Client
+
+    # An API response.  This delegates to a hash containing the parsed
+    # response body.  It also has methods for accessing the response metadata.
+    class Response < SimpleDelegator
+
+      # @param code [Integer] The http status code
+      # @param body_str [String] The JSON encoded response body.
+      def initialize(code, body_str)
+        @code = code
+        @payload = MultiJson.load(body_str)
+        super(@payload)
+      end
+
+      # @return [Integer] The HTTP response code
+      attr_reader :code
+    end
+  end
+end

--- a/lib/govuk/client/url_arbiter.rb
+++ b/lib/govuk/client/url_arbiter.rb
@@ -1,8 +1,9 @@
 require "govuk/client/url_arbiter/version"
+require "govuk/client/response"
+require "govuk/client/errors"
 
 require "rest-client"
 require "multi_json"
-require "govuk/client/errors"
 
 module GOVUK
   module Client
@@ -16,18 +17,37 @@ module GOVUK
       # Fetch details of a path
       #
       # @param path [String] the path to fetch
-      # @return [Hash, nil] The response parsed into a hash, or nil if the path wasn't found.
+      # @return [Response, nil] Details of the reserved path, or +nil+ if the path wasn't found.
       def path(path)
         get_json("/paths#{path}")
+      end
+
+      # Reserve a path
+      #
+      # @param path [String] the path to reserve.
+      # @param details [Hash] the request data to be sent to url-arbiter.
+      # @return [Response] Details of the reserved path.
+      # @raise [Errors::Conflict] if the path is already reserved by another app.
+      # @raise [Errors::UnprocessableEntity] for any validation errors.
+      def reserve_path(path, details)
+        put_json!("/paths#{path}", details)
       end
 
       private
 
       def get_json(path)
         response = RestClient.get(@base_url.merge(path).to_s)
-        MultiJson.load(response)
+        Response.new(response.code, response.body)
       rescue RestClient::ResourceNotFound, RestClient::Gone
         nil
+      rescue RestClient::Exception => e
+        raise Errors.create_for(e)
+      end
+
+      def put_json!(path, data)
+        json = MultiJson.dump(data)
+        response = RestClient.put(@base_url.merge(path).to_s, json, {:content_type => 'application/json'})
+        Response.new(response.code, response.body)
       rescue RestClient::Exception => e
         raise Errors.create_for(e)
       end


### PR DESCRIPTION
This introduces a `Response` class that inherits from `Hash`.  This allows
us to add methods for accessing the response metadata.  Initially, this
is only the status code, but more will be added in time.
