### PR TITLE
Lower dependency on rest-client.

### DIFF
--- a/govuk-client-url_arbiter.gemspec
+++ b/govuk-client-url_arbiter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", '~> 1.7'
+  spec.add_dependency "rest-client", '~> 1.6'
   spec.add_dependency "multi_json", "~> 1.0"
 
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Necessary so that this and the current gds-api-adapters can be used at
the same time.
