### PR TITLE
Handle non-JSON response bodies

### DIFF
--- a/lib/govuk/client/response.rb
+++ b/lib/govuk/client/response.rb
@@ -6,18 +6,29 @@ module GOVUK
 
     # An API response.  This delegates to a hash containing the parsed
     # response body.  It also has methods for accessing the response metadata.
+    #
+    # This is expected to represent a HTTP response with a JSON body, but in
+    # the case where the body is not JSON (eg for some error responses), this
+    # will delegate to an empty Hash.  The raw response can then be accessed
+    # via the {#raw_body} accessor.
     class Response < SimpleDelegator
 
       # @param code [Integer] The http status code
       # @param body_str [String] The JSON encoded response body.
       def initialize(code, body_str)
         @code = code
-        @payload = MultiJson.load(body_str)
-        super(@payload)
+        @raw_body = body_str
+        super(MultiJson.load(@raw_body))
+      rescue MultiJson::ParseError
+        # Delegate to empty hash so that this instance still quacks like a hash.
+        super({})
       end
 
       # @return [Integer] The HTTP response code
       attr_reader :code
+
+      # @return [String] The raw HTTP response body
+      attr_reader :raw_body
     end
   end
 end

--- a/spec/url_arbiter_spec.rb
+++ b/spec/url_arbiter_spec.rb
@@ -145,5 +145,19 @@ describe GOVUK::Client::URLArbiter do
       }
     end
 
+    # FIXME: extract this test into separate unit tests for the generic JSON
+    # client stuff when that is extracted into a separate gem.
+    it "should handle error responses that don't include a JSON body" do
+      stub_request(:put, "#{base_url}/paths/foo/bar").
+        to_return(:status => 500, :body => "Computer says no!")
+
+      expect {
+        response = client.reserve_path("/foo/bar", "publishing_app" => "foo_publisher")
+      }.to raise_error(GOVUK::Client::Errors::HTTPError) { |error|
+        expect(error.code).to eq(500)
+        expect(error.response.raw_body).to eq("Computer says no!")
+        expect(error.response).to eq({})
+      }
+    end
   end
 end


### PR DESCRIPTION
Previously the Response constructor would blow up if given a non-JSON
response body.  This adds handling for this case.
