### PR TITLE
Add a default endpoint that's looked up with Plek

### DIFF
--- a/govuk-client-url_arbiter.gemspec
+++ b/govuk-client-url_arbiter.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rest-client", '~> 1.6'
   spec.add_dependency "multi_json", "~> 1.0"
+  spec.add_dependency "plek", '~> 1.8'
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "gem_publisher", "~> 1.4"

--- a/lib/govuk/client/url_arbiter.rb
+++ b/lib/govuk/client/url_arbiter.rb
@@ -2,6 +2,7 @@ require "govuk/client/url_arbiter/version"
 require "govuk/client/response"
 require "govuk/client/errors"
 
+require "plek"
 require "rest-client"
 require "multi_json"
 
@@ -9,8 +10,11 @@ module GOVUK
   module Client
     class URLArbiter
 
-      # @param base_url [String] the base URL for the service (eg http://url-arbiter.example.com).
-      def initialize(base_url)
+      # @param base_url [String] the base URL for the service (eg
+      #   https://url-arbiter.example.com).  If unspecified, this will be
+      #   looked up with {https://github.com/alphagov/plek Plek}.
+      def initialize(base_url = nil)
+        base_url ||= Plek.new.find('url-arbiter')
         @base_url = URI.parse(base_url)
       end
 


### PR DESCRIPTION
99% of the time, this will be used with the endpoint returned by Plek,
so it makes sense for this to be the default behaviour.
