### PR TITLE
Raise an error when given a known bad path.

### DIFF
--- a/lib/govuk/client/url_arbiter.rb
+++ b/lib/govuk/client/url_arbiter.rb
@@ -43,7 +43,7 @@ module GOVUK
 
       def check_path(path)
         unless path && path.start_with?("/")
-          raise Errors::BaseError.new("Path cannot be blank")
+          raise ArgumentError, "Path must start with a '/'"
         end
       end
 

--- a/lib/govuk/client/url_arbiter.rb
+++ b/lib/govuk/client/url_arbiter.rb
@@ -23,6 +23,7 @@ module GOVUK
       # @param path [String] the path to fetch
       # @return [Response, nil] Details of the reserved path, or +nil+ if the path wasn't found.
       def path(path)
+        check_path(path)
         get_json("/paths#{path}")
       end
 
@@ -34,10 +35,17 @@ module GOVUK
       # @raise [Errors::Conflict] if the path is already reserved by another app.
       # @raise [Errors::UnprocessableEntity] for any validation errors.
       def reserve_path(path, details)
+        check_path(path)
         put_json!("/paths#{path}", details)
       end
 
       private
+
+      def check_path(path)
+        unless path && path.start_with?("/")
+          raise Errors::BaseError.new("Path cannot be blank")
+        end
+      end
 
       def get_json(path)
         response = RestClient.get(@base_url.merge(path).to_s)

--- a/spec/url_arbiter_spec.rb
+++ b/spec/url_arbiter_spec.rb
@@ -19,6 +19,24 @@ describe GOVUK::Client::URLArbiter do
       expect(response).to eq(data)
     end
 
+    it "should raise an error if the path is nil" do
+      expect {
+        response = client.path(nil)
+      }.to raise_error(GOVUK::Client::Errors::BaseError)
+    end
+
+    it "should raise an error if the path is empty" do
+      expect {
+        response = client.path("")
+      }.to raise_error(GOVUK::Client::Errors::BaseError)
+    end
+
+    it "should raise an error if the path doesn't start with a slash" do
+      expect {
+        response = client.path("bacon")
+      }.to raise_error(GOVUK::Client::Errors::BaseError)
+    end
+
     it "should return nil on 404" do
       stub_request(:get, "#{base_url}/paths/foo/bar").
         to_return(:status => 404)
@@ -65,6 +83,24 @@ describe GOVUK::Client::URLArbiter do
       expect(response).to be_a(GOVUK::Client::Response)
       expect(response.code).to eq(201)
       expect(response).to eq(data)
+    end
+
+    it "should raise an error if the path is nil" do
+      expect {
+        response = client.reserve_path(nil, {})
+      }.to raise_error(GOVUK::Client::Errors::BaseError)
+    end
+
+    it "should raise an error if the path is empty" do
+      expect {
+        response = client.reserve_path("", {})
+      }.to raise_error(GOVUK::Client::Errors::BaseError)
+    end
+
+    it "should raise an error if the path doesn't start with a slash" do
+      expect {
+        response = client.reserve_path("bacon", {})
+      }.to raise_error(GOVUK::Client::Errors::BaseError)
     end
 
     it "should raise a conflict error if the path is already reserved" do

--- a/spec/url_arbiter_spec.rb
+++ b/spec/url_arbiter_spec.rb
@@ -22,19 +22,19 @@ describe GOVUK::Client::URLArbiter do
     it "should raise an error if the path is nil" do
       expect {
         response = client.path(nil)
-      }.to raise_error(GOVUK::Client::Errors::BaseError)
+      }.to raise_error(ArgumentError)
     end
 
     it "should raise an error if the path is empty" do
       expect {
         response = client.path("")
-      }.to raise_error(GOVUK::Client::Errors::BaseError)
+      }.to raise_error(ArgumentError)
     end
 
     it "should raise an error if the path doesn't start with a slash" do
       expect {
         response = client.path("bacon")
-      }.to raise_error(GOVUK::Client::Errors::BaseError)
+      }.to raise_error(ArgumentError)
     end
 
     it "should return nil on 404" do
@@ -88,19 +88,19 @@ describe GOVUK::Client::URLArbiter do
     it "should raise an error if the path is nil" do
       expect {
         response = client.reserve_path(nil, {})
-      }.to raise_error(GOVUK::Client::Errors::BaseError)
+      }.to raise_error(ArgumentError)
     end
 
     it "should raise an error if the path is empty" do
       expect {
         response = client.reserve_path("", {})
-      }.to raise_error(GOVUK::Client::Errors::BaseError)
+      }.to raise_error(ArgumentError)
     end
 
     it "should raise an error if the path doesn't start with a slash" do
       expect {
         response = client.reserve_path("bacon", {})
-      }.to raise_error(GOVUK::Client::Errors::BaseError)
+      }.to raise_error(ArgumentError)
     end
 
     it "should raise a conflict error if the path is already reserved" do


### PR DESCRIPTION
There are a few cases where a bad path (`nil`, the empty string, and a string that doesn’t start with `/`) could cause the client to make a nonsense request to the arbiter. Rather than make this request and rely on the URL arbiter to fail, we can add checks in the client to make sure that all the requests make sense.
