### PR TITLE
All client errors should inherit from BaseError...

### DIFF
--- a/lib/govuk/client/errors.rb
+++ b/lib/govuk/client/errors.rb
@@ -34,6 +34,8 @@ module GOVUK
 
       class Timeout < BaseError; end
 
+      class InvalidPath < BaseError; end
+
       class HTTPError < BaseError
         # @api private
         def initialize(restclient_exception)

--- a/lib/govuk/client/url_arbiter.rb
+++ b/lib/govuk/client/url_arbiter.rb
@@ -22,7 +22,7 @@ module GOVUK
       #
       # @param path [String] the path to fetch
       # @return [Response, nil] Details of the reserved path, or +nil+ if the path wasn't found.
-      # @raise [ArgumentError] when called with an invalid path.
+      # @raise [Errors::InvalidPath] when called with an invalid path.
       def path(path)
         check_path(path)
         get_json("/paths#{path}")
@@ -35,7 +35,7 @@ module GOVUK
       # @return [Response] Details of the reserved path.
       # @raise [Errors::Conflict] if the path is already reserved by another app.
       # @raise [Errors::UnprocessableEntity] for any validation errors.
-      # @raise [ArgumentError] when called with an invalid path.
+      # @raise [Errors::InvalidPath] when called with an invalid path.
       def reserve_path(path, details)
         check_path(path)
         put_json!("/paths#{path}", details)
@@ -45,7 +45,7 @@ module GOVUK
 
       def check_path(path)
         unless path && path.start_with?("/")
-          raise ArgumentError, "Path must start with a '/'"
+          raise Errors::InvalidPath, "Path must start with a '/'"
         end
       end
 

--- a/lib/govuk/client/url_arbiter/version.rb
+++ b/lib/govuk/client/url_arbiter/version.rb
@@ -1,7 +1,7 @@
 module GOVUK
   module Client
     class URLArbiter
-      VERSION = "0.0.2"
+      VERSION = "0.0.3"
     end
   end
 end

--- a/spec/url_arbiter_spec.rb
+++ b/spec/url_arbiter_spec.rb
@@ -22,19 +22,19 @@ describe GOVUK::Client::URLArbiter do
     it "should raise an error if the path is nil" do
       expect {
         response = client.path(nil)
-      }.to raise_error(ArgumentError)
+      }.to raise_error(GOVUK::Client::Errors::InvalidPath)
     end
 
     it "should raise an error if the path is empty" do
       expect {
         response = client.path("")
-      }.to raise_error(ArgumentError)
+      }.to raise_error(GOVUK::Client::Errors::InvalidPath)
     end
 
     it "should raise an error if the path doesn't start with a slash" do
       expect {
         response = client.path("bacon")
-      }.to raise_error(ArgumentError)
+      }.to raise_error(GOVUK::Client::Errors::InvalidPath)
     end
 
     it "should return nil on 404" do
@@ -88,19 +88,19 @@ describe GOVUK::Client::URLArbiter do
     it "should raise an error if the path is nil" do
       expect {
         response = client.reserve_path(nil, {})
-      }.to raise_error(ArgumentError)
+      }.to raise_error(GOVUK::Client::Errors::InvalidPath)
     end
 
     it "should raise an error if the path is empty" do
       expect {
         response = client.reserve_path("", {})
-      }.to raise_error(ArgumentError)
+      }.to raise_error(GOVUK::Client::Errors::InvalidPath)
     end
 
     it "should raise an error if the path doesn't start with a slash" do
       expect {
         response = client.reserve_path("bacon", {})
-      }.to raise_error(ArgumentError)
+      }.to raise_error(GOVUK::Client::Errors::InvalidPath)
     end
 
     it "should raise a conflict error if the path is already reserved" do


### PR DESCRIPTION
This ensures that consumers of the client can
rescue from client errors and act accordingly.
If this raises an ArgumentError, consuming 
applications would be forced to rescue from this
which could lead to very misleading and hard to
find bugs.
